### PR TITLE
Add assertion to ensure valid command input

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,5 @@ shadowJar {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/data/tasks.txt
+++ b/data/tasks.txt
@@ -5,3 +5,4 @@ T | 0 | borrow book
 D | 0 | return book | 12/12/2025 1900
 E | 0 | project meeting | 2/12/2022 1600 | 19/12/2022 1900
 T | 0 | booking
+T | 0 | book

--- a/src/main/java/mysutong/Parser.java
+++ b/src/main/java/mysutong/Parser.java
@@ -16,6 +16,7 @@ public class Parser {
      */
     public void executeCommand(String fullCommand, TaskList tasks, Ui ui, Storage storage) {
         String[] inputs = fullCommand.split(" ", 2);
+        assert (inputs.length > 0);
         String command = inputs[0];
 
         try {


### PR DESCRIPTION
The executeCommand method in Parser handles user commands by splitting the input string into two parts: the command itself and any additional arguments.

Currently, the split operation does not validate that the input string contains at least one element, which could potentially lead to unexpected behaviour or bugs if empty input is passed.

To mitigate this, let's add an assert statement to ensure that the inputs array has at least one element. This ensures that the code always receives a valid command to process. In situations where assertions are enabled, this will help catch empty or invalid commands during development and testing.

While this doesn't address user input validation directly (since assert can be disabled in production), it adds an extra layer of safety during development.

This change also avoids unnecessary array access errors and improves the stability of the command handling logic.